### PR TITLE
Cache configuration in AppSettings

### DIFF
--- a/UDC.Common/AppSettings.cs
+++ b/UDC.Common/AppSettings.cs
@@ -1,40 +1,31 @@
-﻿using System;
-using System.Diagnostics;
+using System;
 using System.IO;
 using Microsoft.Extensions.Configuration;
 
 namespace UDC.Common
 {
-
-
     public class AppSettings
     {
-        public static String GetValue(String key)
+        private static readonly Lazy<IConfigurationRoot> _configuration = new Lazy<IConfigurationRoot>(() =>
         {
-            String retVal = "";
-            String env = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-
+            var env = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
             if (string.IsNullOrWhiteSpace(env))
                 env = "LOCAL";
 
             var pathToContentRoot = Directory.GetCurrentDirectory();
 
-            //TODO: dont load  many times, cache this
-            IConfigurationBuilder objCfgBuilder = new ConfigurationBuilder()
+            return new ConfigurationBuilder()
                 .SetBasePath(pathToContentRoot)
                 .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
                 .AddJsonFile($"appsettings.{env}.json", optional: true, reloadOnChange: true)
-                .AddEnvironmentVariables();
-                
-            IConfigurationRoot objCfg = objCfgBuilder.Build(); 
+                .AddEnvironmentVariables()
+                .Build();
+        });
 
-            retVal = objCfg.GetValue<String>(key);
-
-            objCfg = null;
-            objCfgBuilder = null;
-            env = null;
-
-            return retVal;
+        public static string GetValue(string key)
+        {
+            return _configuration.Value.GetValue<string>(key);
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- Lazy-load configuration once in AppSettings and reuse for value lookups.
- Remove manual null assignments and rely on garbage collection.

## Testing
- `dotnet build UDC.Common/UDC.Common.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68996ee669fc8328a352d8646f342b48