### PR TITLE
Fix GraphQL GUID field serialization

### DIFF
--- a/DataConnectorUI/GraphQL/Types/IntegratorType.cs
+++ b/DataConnectorUI/GraphQL/Types/IntegratorType.cs
@@ -1,4 +1,5 @@
-﻿using GraphQL.Types;
+﻿using System;
+using GraphQL.Types;
 using UDC.Common.Data.Models;
 using UDC.Common.Interfaces;
 
@@ -8,8 +9,24 @@ namespace DataConnectorUI.GraphQL.Types
     {
         public IntegratorType()
         {
+            // The unique identifier is a Guid. Use IdGraphType to properly
+            // expose it as a GraphQL ID scalar rather than relying on string
+            // serialisation which was causing runtime errors.
+            Field<IdGraphType>(
+                "integratorID",
+                resolve: context =>
+                {
+                    // Return null if the source or its ID is missing.
+                    var id = context.Source?.IntegratorID;
+
+                    // Guid.Empty indicates the identifier has not been assigned.
+                    return id.HasValue && id.Value != Guid.Empty ? id : null;
+                });
+
+            // Name of the integrator.
             Field(x => x.Name, type: typeof(StringGraphType));
-            Field(x => x.IntegratorID, type: typeof(StringGraphType));
+
+            // Platform-specific configuration represented as a string blob.
             Field(x => x.PlatformConfig, type: typeof(StringGraphType));
         }
     }

--- a/DataConnectorUI/GraphQL/Types/PlatformType.cs
+++ b/DataConnectorUI/GraphQL/Types/PlatformType.cs
@@ -14,9 +14,21 @@ namespace DataConnectorUI.GraphQL.Types
     {
         public PlatformType()
         {
-            Field(x => x.PlatformID, type: typeof(StringGraphType));
-            Field(x => x.Name, type: typeof(StringGraphType));
+            // PlatformID is a Guid in the model. Resolve it through the
+            // IdGraphType to ensure proper serialisation for GraphQL clients.
+            Field<IdGraphType>(
+                "platformID",
+                resolve: context =>
+                {
+                    // Return null if the source or its ID is missing.
+                    var id = context.Source?.PlatformID;
 
+                    // Guid.Empty indicates the identifier has not been assigned.
+                    return id.HasValue && id.Value != Guid.Empty ? id : null;
+                });
+
+            // Name is simple string field.
+            Field(x => x.Name, type: typeof(StringGraphType));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Return null from GraphQL ID resolvers when platform or integrator IDs are missing or Guid.Empty
- Guard against null context.Source to prevent runtime errors

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden for Ubuntu repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68998a5633e88328ad30c9e5999c5923