### PR TITLE
Fix integrator selection persistence in ConnectionForm

### DIFF
--- a/DataConnectorUI/assets/src/apps/Containers/ConnectionForm/ConnectionForm.jsx
+++ b/DataConnectorUI/assets/src/apps/Containers/ConnectionForm/ConnectionForm.jsx
@@ -347,7 +347,7 @@ const StringifyConfig = o => {
     var val = e.target.value;
     setSourcePlatformIntegrator(val);
     var newSource = Object.assign({}, sourcePlatformCfg, {
-      IntegratorID: val.integratorID
+      integratorID: val.integratorID
     });
     setSourcePlatformCfg(newSource);
   };
@@ -369,7 +369,7 @@ const StringifyConfig = o => {
 
     setDestinationPlatformIntegrator(val);
     var newSource = Object.assign({}, destinationPlatformCfg, {
-      IntegratorID: val.integratorID
+      integratorID: val.integratorID
     });
     setDestinationPlatformCfg(newSource);
   };


### PR DESCRIPTION
## Summary
- ensure integrator selection state uses `integratorID` keys for both source and destination

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689aa039b6008328b46aacb3066d4814