### PR TITLE
Inject DatabaseContext into ProviderHelpers

### DIFF
--- a/DataConnectorUI/Controllers/Api/AdminApiController.cs
+++ b/DataConnectorUI/Controllers/Api/AdminApiController.cs
@@ -442,7 +442,7 @@ namespace DataConnectorUI.Controllers.Api
 
             try
             {
-                IIntegrator objTargetIntegrator = ProviderHelpers.GetIntegrator(connectionID, Targets.Source);
+                IIntegrator objTargetIntegrator = ProviderHelpers.GetIntegrator(connectionID, Targets.Source, _databaseContext);
                 if (objTargetIntegrator != null)
                 {
                     objRetVal.data = objTargetIntegrator.GetContainers();
@@ -466,7 +466,7 @@ namespace DataConnectorUI.Controllers.Api
 
             try
             {
-                IIntegrator objTargetIntegrator = ProviderHelpers.GetIntegrator(connectionID, Targets.Destination);
+                IIntegrator objTargetIntegrator = ProviderHelpers.GetIntegrator(connectionID, Targets.Destination, _databaseContext);
                 if (objTargetIntegrator != null)
                 {
                     objRetVal.data = objTargetIntegrator.GetContainers();
@@ -490,7 +490,7 @@ namespace DataConnectorUI.Controllers.Api
 
             try
             {
-                IIntegrator objTargetIntegrator = ProviderHelpers.GetIntegrator(connectionID, Targets.Source);
+                IIntegrator objTargetIntegrator = ProviderHelpers.GetIntegrator(connectionID, Targets.Source, _databaseContext);
                 if (objTargetIntegrator != null)
                 {
                     objRetVal.data = objTargetIntegrator.GetFields(containerId);
@@ -514,7 +514,7 @@ namespace DataConnectorUI.Controllers.Api
 
             try
             {
-                IIntegrator objTargetIntegrator = ProviderHelpers.GetIntegrator(connectionID, Targets.Destination);
+                IIntegrator objTargetIntegrator = ProviderHelpers.GetIntegrator(connectionID, Targets.Destination, _databaseContext);
                 if (objTargetIntegrator != null)
                 {
                     objRetVal.data = objTargetIntegrator.GetFields(containerId);

--- a/DataConnectorUI/Repositories/ConnectionRepository.cs
+++ b/DataConnectorUI/Repositories/ConnectionRepository.cs
@@ -151,17 +151,17 @@ namespace DataConnectorUI.Repositories
 
         public IOrderedEnumerable<SyncField> GetSourceFields(Int64 connectionId, string containerId)
         {
-            IIntegrator objTargetIntegrator = ProviderHelpers.GetIntegrator(connectionId, ProviderHelpers.Targets.Source);
+            IIntegrator objTargetIntegrator = ProviderHelpers.GetIntegrator(connectionId, ProviderHelpers.Targets.Source, _myDbContext);
             return objTargetIntegrator?.GetFields(containerId).OrderBy(field => !string.IsNullOrEmpty(field.Title) ? field.Title : field.Key);
         }
         public IOrderedEnumerable<SyncField> GetDestinationFields(Int64 connectionId, string containerId)
         {
-            IIntegrator objTargetIntegrator = ProviderHelpers.GetIntegrator(connectionId, ProviderHelpers.Targets.Destination);
+            IIntegrator objTargetIntegrator = ProviderHelpers.GetIntegrator(connectionId, ProviderHelpers.Targets.Destination, _myDbContext);
             return objTargetIntegrator?.GetFields(containerId).OrderBy(field => !string.IsNullOrEmpty(field.Title) ? field.Title : field.Key);
         }
         public List<SyncContainer> GetSourceContainers(int connectionId)
         {
-            IIntegrator objTargetIntegrator = ProviderHelpers.GetIntegrator(connectionId, ProviderHelpers.Targets.Source);
+            IIntegrator objTargetIntegrator = ProviderHelpers.GetIntegrator(connectionId, ProviderHelpers.Targets.Source, _myDbContext);
             return objTargetIntegrator?.GetContainers();
         }
 
@@ -169,7 +169,7 @@ namespace DataConnectorUI.Repositories
         {
             if (!string.IsNullOrEmpty(containerId))
             {
-                IIntegrator objTargetIntegrator = ProviderHelpers.GetIntegrator(connectionId, ProviderHelpers.Targets.Source);
+                IIntegrator objTargetIntegrator = ProviderHelpers.GetIntegrator(connectionId, ProviderHelpers.Targets.Source, _myDbContext);
                 var q = objTargetIntegrator?.GetContainers();
 
                 return objTargetIntegrator?.GetContainers().FirstOrDefault(x => x.Id.ToString() == containerId);
@@ -180,7 +180,7 @@ namespace DataConnectorUI.Repositories
 
         public List<SyncContainer> GetDestinationContainers(int connectionId)
         {
-            IIntegrator objTargetIntegrator = ProviderHelpers.GetIntegrator(connectionId, ProviderHelpers.Targets.Destination);
+            IIntegrator objTargetIntegrator = ProviderHelpers.GetIntegrator(connectionId, ProviderHelpers.Targets.Destination, _myDbContext);
             return objTargetIntegrator?.GetContainers();
         }
 
@@ -188,7 +188,7 @@ namespace DataConnectorUI.Repositories
         {
             if (!string.IsNullOrEmpty(containerId))
             {
-                IIntegrator objTargetIntegrator = ProviderHelpers.GetIntegrator(connectionId, ProviderHelpers.Targets.Destination);
+                IIntegrator objTargetIntegrator = ProviderHelpers.GetIntegrator(connectionId, ProviderHelpers.Targets.Destination, _myDbContext);
                 var q = objTargetIntegrator?.GetContainers();
                 return objTargetIntegrator?.GetContainers().FirstOrDefault(x => x.Id.ToString() == containerId);
             }

--- a/UDC.DataConnectorCore/ProviderHelpers.cs
+++ b/UDC.DataConnectorCore/ProviderHelpers.cs
@@ -12,7 +12,6 @@ using UDC.Common.Data.Models.Configuration;
 using UDC.Common.Data;
 using UDC.Common.Database.Data.Models.Database;
 using UDC.Common.Database.Data;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace UDC.DataConnectorCore
 {
@@ -86,13 +85,11 @@ namespace UDC.DataConnectorCore
 
             return retVal;
         }
-        public static IIntegrator GetIntegrator(Int64 connectionID, Targets target)
+        public static IIntegrator GetIntegrator(Int64 connectionID, Targets target, DatabaseContext databaseContext)
         {
             IIntegrator objIntegrator = null;
 
-            var objDB = ServiceLocator.Instance.GetRequiredService<DatabaseContext>();
-
-            Connection objEntity = objDB.Connections.Where(obj => obj.Id == connectionID).FirstOrDefault();
+            Connection objEntity = databaseContext.Connections.Where(obj => obj.Id == connectionID).FirstOrDefault();
                 if (objEntity != null)
                 {
                     PlatformCfg objPlatformCfg = null;
@@ -116,7 +113,6 @@ namespace UDC.DataConnectorCore
                     objPlatformCfg = null;
                 }
                 objEntity = null;
-            
 
             return objIntegrator;
         }


### PR DESCRIPTION
## Summary
- Pass DatabaseContext into ProviderHelpers.GetIntegrator instead of using a service locator
- Update AdminApiController to provide its injected DatabaseContext when resolving integrators
- Update ConnectionRepository to pass DatabaseContext for integrator lookups

## Testing
- ⚠️ `dotnet build UniversalDataConnector.sln` (dotnet: command not found)
- ⚠️ `apt-get update` (403 Forbidden; repository not signed)


------
https://chatgpt.com/codex/tasks/task_e_68a7ee26c5d883288e12f1eb51ea10f1