### PR TITLE
Refactor SharePointOnline provider to use PlatformIO

### DIFF
--- a/UDC.SharePointOnline.GraphService/GraphService.cs
+++ b/UDC.SharePointOnline.GraphService/GraphService.cs
@@ -2,10 +2,14 @@ using UDC.Common;
 using Microsoft.Graph;
 using Microsoft.Graph.Auth;
 using Microsoft.Identity.Client;
+using GraphList = Microsoft.Graph.List;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 
 namespace Equ.SharePoint.GraphService
 {
@@ -13,6 +17,7 @@ namespace Equ.SharePoint.GraphService
     {
         public GraphServiceClient client;
         private string driveId;
+        private string siteId;
 
         public GraphService(
             string tenantId,
@@ -39,6 +44,8 @@ namespace Equ.SharePoint.GraphService
                     throw new Exception($"SharePoint site '{sitePath}' at '{siteDomain}' not found.");
                 }
 
+                siteId = site.Id;
+
                 var drives = await client.Sites[site.Id]
                                          .Drives
                                          .Request()
@@ -50,29 +57,288 @@ namespace Equ.SharePoint.GraphService
             });
         }
 
-        public Task<IEnumerable<Dictionary<string, object>>> GetListsAsync()
+        public async Task<IEnumerable<Dictionary<string, object>>> GetListsAsync()
         {
-            throw new NotImplementedException();
+            var results = new List<Dictionary<string, object>>();
+
+            var list = await client.Drives[driveId]
+                                    .List
+                                    .Request()
+                                    .Expand("Columns")
+                                    .GetAsync()
+                                    .ConfigureAwait(false);
+
+            if (list != null)
+            {
+                results.Add(ConvertList(list));
+            }
+
+            return results;
         }
 
-        public Task<Dictionary<string, object>> GetListAsync(Guid id)
+        public async Task<Dictionary<string, object>> GetListAsync(Guid id)
         {
-            throw new NotImplementedException();
+            var list = await client.Sites[siteId]
+                                   .Lists[id.ToString()]
+                                   .Request()
+                                   .Expand("Columns")
+                                   .GetAsync()
+                                   .ConfigureAwait(false);
+
+            if (list == null)
+            {
+                return null;
+            }
+
+            var result = ConvertList(list);
+
+            var root = await client.Drives[driveId]
+                                    .Root
+                                    .Request()
+                                    .GetAsync()
+                                    .ConfigureAwait(false);
+
+            var contents = await GetFolderContentsAsync(root.Id);
+            result.Add("Folders", contents["Folders"]);
+            result.Add("Documents", contents["Documents"]);
+
+            return result;
         }
 
-        public Task<IEnumerable<Dictionary<string, object>>> GetDocumentsAsync(Guid listId, IEnumerable<string> fields)
+        public async Task<IEnumerable<Dictionary<string, object>>> GetDocumentsAsync(Guid listId, IEnumerable<string> fields)
         {
-            throw new NotImplementedException();
+            var items = await client.Sites[siteId]
+                                     .Lists[listId.ToString()]
+                                     .Items
+                                     .Request()
+                                     .Expand("Fields,DriveItem")
+                                     .GetAsync()
+                                     .ConfigureAwait(false);
+
+            var results = new List<Dictionary<string, object>>();
+
+            if (items != null)
+            {
+                foreach (var item in items.Where(i => i?.DriveItem != null))
+                {
+                    var dict = ConvertFile(item.DriveItem);
+
+                    if (fields != null && item.Fields != null && item.Fields.AdditionalData != null)
+                    {
+                        foreach (var field in fields)
+                        {
+                            if (item.Fields.AdditionalData.ContainsKey(field))
+                            {
+                                dict[field] = item.Fields.AdditionalData[field];
+                            }
+                            else
+                            {
+                                dict[field] = null;
+                            }
+                        }
+                    }
+
+                    results.Add(dict);
+                }
+            }
+
+            return results;
         }
 
-        public Task<IEnumerable<Dictionary<string, object>>> GetTermSetsAsync()
+        public async Task<IEnumerable<Dictionary<string, object>>> GetTermSetsAsync()
         {
-            throw new NotImplementedException();
+            var results = new List<Dictionary<string, object>>();
+
+            var baseUrl = client.Sites[siteId].Request().RequestUrl;
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}/termStore/sets");
+            await client.AuthenticationProvider.AuthenticateRequestAsync(request).ConfigureAwait(false);
+            var response = await client.HttpProvider.SendAsync(request).ConfigureAwait(false);
+            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            var json = JObject.Parse(content);
+            var sets = json["value"] as JArray;
+            if (sets != null)
+            {
+                foreach (var set in sets)
+                {
+                    var dict = new Dictionary<string, object>
+                    {
+                        {"Id", (string)set["id"]},
+                        {"Name", (string)set["localizedNames"]?.First?()["name"]}
+                    };
+                    results.Add(dict);
+                }
+            }
+
+            return results;
         }
 
-        public Task<IEnumerable<Dictionary<string, object>>> GetTermsAsync(Guid termSetId)
+        public async Task<IEnumerable<Dictionary<string, object>>> GetTermsAsync(Guid termSetId)
         {
-            throw new NotImplementedException();
+            var results = new List<Dictionary<string, object>>();
+
+            var baseUrl = client.Sites[siteId].Request().RequestUrl;
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}/termStore/sets/{termSetId}/terms?$expand=children");
+            await client.AuthenticationProvider.AuthenticateRequestAsync(request).ConfigureAwait(false);
+            var response = await client.HttpProvider.SendAsync(request).ConfigureAwait(false);
+            var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            var json = JObject.Parse(content);
+            var terms = json["value"] as JArray;
+            if (terms != null)
+            {
+                foreach (var term in terms)
+                {
+                    results.Add(ConvertTerm(term));
+                }
+            }
+
+            return results;
+        }
+
+        private Dictionary<string, object> ConvertList(GraphList list)
+        {
+            var dest = new Dictionary<string, object>();
+            dest.Add("Id", list.Id);
+            dest.Add("Title", list.DisplayName);
+
+            if (list.Columns != null)
+            {
+                var fields = new List<Dictionary<string, object>>();
+                foreach (var column in list.Columns)
+                {
+                    fields.Add(ConvertField(column));
+                }
+                dest.Add("Fields", fields);
+            }
+            else
+            {
+                dest.Add("Fields", null);
+            }
+
+            return dest;
+        }
+
+        private Dictionary<string, object> ConvertField(ColumnDefinition column)
+        {
+            var dest = new Dictionary<string, object>();
+            dest.Add("Id", column.Id);
+            dest.Add("InternalName", column.Name);
+            dest.Add("Title", column.DisplayName);
+            dest.Add("Type", GetColumnType(column));
+            dest.Add("ClrType", column.GetType().ToString());
+            dest.Add("TermSetId", null);
+            return dest;
+        }
+
+        private string GetColumnType(ColumnDefinition column)
+        {
+            if (column.AdditionalData != null)
+            {
+                if (column.AdditionalData.ContainsKey("columnType"))
+                {
+                    return column.AdditionalData["columnType"]?.ToString();
+                }
+                if (column.AdditionalData.ContainsKey("odata.type"))
+                {
+                    return column.AdditionalData["odata.type"]?.ToString();
+                }
+            }
+            return null;
+        }
+
+        private Dictionary<string, object> ConvertFolder(DriveItem item)
+        {
+            return new Dictionary<string, object>
+            {
+                {"Id", item.Id},
+                {"ParentId", item.ParentReference != null ? item.ParentReference.Id : null},
+                {"Title", item.Name},
+                {"LastModified", item.LastModifiedDateTime}
+            };
+        }
+
+        private Dictionary<string, object> ConvertFile(DriveItem item)
+        {
+            return new Dictionary<string, object>
+            {
+                {"Id", item.Id},
+                {"FolderId", item.ParentReference != null ? item.ParentReference.Id : null},
+                {"Title", item.Name},
+                {"Name", item.Name},
+                {"Extension", Path.GetExtension(item.Name)},
+                {"TotalSize", item.Size},
+                {"Uploaded", item.File != null},
+                {"LastModified", item.LastModifiedDateTime},
+                {"DateCreated", item.CreatedDateTime}
+            };
+        }
+
+        private async Task<Dictionary<string, object>> GetFolderContentsAsync(string folderId)
+        {
+            var retVal = new Dictionary<string, object>();
+            List<Dictionary<string, object>> folders = null;
+            List<Dictionary<string, object>> documents = null;
+
+            var children = await client.Drives[driveId]
+                                       .Items[folderId]
+                                       .Children
+                                       .Request()
+                                       .GetAsync()
+                                       .ConfigureAwait(false);
+
+            if (children != null)
+            {
+                foreach (var child in children)
+                {
+                    if (child.Folder != null)
+                    {
+                        var folder = ConvertFolder(child);
+                        var sub = await GetFolderContentsAsync(child.Id);
+                        folder.Add("Folders", sub["Folders"]);
+                        folder.Add("Documents", sub["Documents"]);
+                        if (folders == null) folders = new List<Dictionary<string, object>>();
+                        folders.Add(folder);
+                    }
+                    else if (child.File != null)
+                    {
+                        if (documents == null) documents = new List<Dictionary<string, object>>();
+                        documents.Add(ConvertFile(child));
+                    }
+                }
+            }
+
+            retVal.Add("Folders", folders);
+            retVal.Add("Documents", documents);
+            return retVal;
+        }
+
+        private Dictionary<string, object> ConvertTerm(JToken term)
+        {
+            var dest = new Dictionary<string, object>
+            {
+                {"Id", (string)term["id"]},
+                {"Name", (string)term["labels"]?.First?()["name"]}
+            };
+
+            var parentId = term["parent"]?["id"]?.ToString();
+            if (parentId != null)
+            {
+                dest.Add("parentId", parentId);
+            }
+
+            var children = term["children"] as JArray;
+            if (children != null && children.Count > 0)
+            {
+                var childList = new List<Dictionary<string, object>>();
+                foreach (var child in children)
+                {
+                    childList.Add(ConvertTerm(child));
+                }
+                dest.Add("Terms", childList);
+            }
+
+            return dest;
         }
     }
 }

--- a/UDC.SharePointOnline.GraphService/GraphService.cs
+++ b/UDC.SharePointOnline.GraphService/GraphService.cs
@@ -164,7 +164,7 @@ namespace Equ.SharePoint.GraphService
                     var dict = new Dictionary<string, object>
                     {
                         {"Id", (string)set["id"]},
-                        {"Name", (string)set["localizedNames"]?.First?()["name"]}
+                        {"Name", (string)set["localizedNames"]?.First?["name"]}
                     };
                     results.Add(dict);
                 }
@@ -318,7 +318,7 @@ namespace Equ.SharePoint.GraphService
             var dest = new Dictionary<string, object>
             {
                 {"Id", (string)term["id"]},
-                {"Name", (string)term["labels"]?.First?()["name"]}
+                {"Name", (string)term["labels"]?.First?["name"]}
             };
 
             var parentId = term["parent"]?["id"]?.ToString();

--- a/UDC.SharePointOnlineIntegrator/Data/PlatformIO.cs
+++ b/UDC.SharePointOnlineIntegrator/Data/PlatformIO.cs
@@ -24,6 +24,7 @@ namespace UDC.SharePointOnlineIntegrator.Data
             LoadSettings();
             EnsureAdditionalConfigsValid();
         }
+
         public PlatformIO(String endPointURL, String serviceUsername, String servicePassword, String additionalConfigs)
         {
             this.EndPointURL = endPointURL;
@@ -32,6 +33,7 @@ namespace UDC.SharePointOnlineIntegrator.Data
             this.AdditionalConfigs = GeneralHelpers.ParseAdditionalConfigs(additionalConfigs);
             EnsureAdditionalConfigsValid();
         }
+
         public PlatformIO(PlatformCfg cfg, String additionalConfigs = null)
         {
             if (cfg != null)
@@ -41,13 +43,19 @@ namespace UDC.SharePointOnlineIntegrator.Data
                 this.ServicePassword = cfg.ServicePassword;
                 this.AdditionalConfigs = GeneralHelpers.ParseAdditionalConfigs(additionalConfigs ?? cfg.AdditionalConfigs);
                 EnsureAdditionalConfigsValid();
-        }
+            }
             else
-        {
+            {
                 this.AdditionalConfigs = new Dictionary<String, String>();
                 LoadSettings();
                 EnsureAdditionalConfigsValid();
+            }
         }
+
+        public PlatformIO(PlatformCfg cfg, IGraphService graphService, String additionalConfigs = null)
+            : this(cfg, additionalConfigs)
+        {
+            this._graphService = graphService;
         }
 
         private void EnsureAdditionalConfigsValid()
@@ -58,7 +66,7 @@ namespace UDC.SharePointOnlineIntegrator.Data
                 !this.AdditionalConfigs.ContainsKey("driveName"))
             {
                 throw new Exception("Additional configs must contain tenantId, sitePath and driveName.");
-        }
+            }
         }
 
         private void LoadSettings()
@@ -120,17 +128,18 @@ namespace UDC.SharePointOnlineIntegrator.Data
 
             var arrSrcLists = AsyncHelper.RunSync(() => graphService.GetListsAsync());
             if (arrSrcLists != null)
-        {
+            {
                 arrRetVal = arrSrcLists.ToList();
             }
 
             return arrRetVal;
         }
+
         public Dictionary<String, Object> GetList(Guid listId)
-            {
+        {
             IGraphService graphService = GetGraphService();
             return AsyncHelper.RunSync(() => graphService.GetListAsync(listId));
-            }
+        }
         public List<Dictionary<String, Object>> GetDocuments(Guid listId, Boolean includeBinary, List<String> fields)
         {
             List<Dictionary<String, Object>> arrRetVal = null;
@@ -140,10 +149,11 @@ namespace UDC.SharePointOnlineIntegrator.Data
             if (arrSrcFiles != null)
             {
                 arrRetVal = arrSrcFiles.ToList();
-        }
+            }
 
             return arrRetVal;
         }
+
         public List<Dictionary<String, Object>> GetDocuments(List<String> docIds, Boolean includeBinary, List<String> fields)
         {
             List<Dictionary<String, Object>> arrRetVal = null;
@@ -159,7 +169,7 @@ namespace UDC.SharePointOnlineIntegrator.Data
             }
 
             return arrRetVal;
-                }
+        }
         public Dictionary<String, Object> GetDocument(String docId, Boolean includeBinary, List<String> fields)
         {
             List<Dictionary<String, Object>> arrDocs = GetDocuments(new List<String>() { docId }, includeBinary, fields);
@@ -182,20 +192,21 @@ namespace UDC.SharePointOnlineIntegrator.Data
 
             return arrRetVal;
         }
-        //public Dictionary<String, Object> GetTermSet(Guid id, Boolean includeChildren)
-        //{
-        //    IGraphService graphService = GetGraphService();
-        //    var arrTermSets = AsyncHelper.RunSync(() => graphService.GetTermSetsAsync());
-        //    Dictionary<String, Object> objRetVal = arrTermSets?.FirstOrDefault(ts => GeneralHelpers.parseGUID(ts["Id"]) == id);
 
-        //    if (objRetVal != null && includeChildren)
-        //    {
-        //        var arrTerms = AsyncHelper.RunSync(() => graphService.GetTermsAsync(id));
-        //        objRetVal["Terms"] = arrTerms?.ToList();
-        //    }
+        public Dictionary<String, Object> GetTermSet(Guid id, Boolean includeChildren)
+        {
+            IGraphService graphService = GetGraphService();
+            var arrTermSets = AsyncHelper.RunSync(() => graphService.GetTermSetsAsync());
+            Dictionary<String, Object> objRetVal = arrTermSets?.FirstOrDefault(ts => GeneralHelpers.parseGUID(ts["Id"]) == id);
 
-        //    return objRetVal;
-        //}
+            if (objRetVal != null && includeChildren)
+            {
+                var arrTerms = AsyncHelper.RunSync(() => graphService.GetTermsAsync(id));
+                objRetVal["Terms"] = arrTerms?.ToList();
+            }
+
+            return objRetVal;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add optional GraphService constructor and term set retrieval to PlatformIO
- refactor SharePointOnlineDocumentsProvider to use PlatformIO for lists, documents, and term sets
- implement GraphService methods for lists, documents, and taxonomy retrieval
- rework GraphService term store calls to raw HTTP and JSON parsing for compatibility with older Graph SDK

## Testing
- `dotnet build UDC.SharePointOnline.GraphService/UDC.SharePointOnline.GraphService.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8070ce6a48328b12b1064820e9a65